### PR TITLE
Upgrade setup tools for mock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ lint: .venv
 .venv:
 	sudo apt-get install -qy python-virtualenv libpq-dev python-dev
 	virtualenv .venv
+	$(PYHOME)/pip install --upgrade setuptools
 	$(PYTHON) setup.py develop
 
 npm:


### PR DESCRIPTION
```
Processing nose-1.3.7.tar.gz
Writing /tmp/easy_install-pJ53oJ/nose-1.3.7/setup.cfg
Running nose-1.3.7/setup.py -q bdist_egg --dist-dir /tmp/easy_install-pJ53oJ/nose-1.3.7/egg-dist-tmp-EDJ9op
no previously-included directories found matching 'doc/.build'
Adding nose 1.3.7 to easy-install.pth file
Installing nosetests script to /opt/benchmark-gui/.venv/bin
Installing nosetests-2.7 script to /opt/benchmark-gui/.venv/bin

Installed /opt/benchmark-gui/.venv/lib/python2.7/site-packages/nose-1.3.7-py2.7.egg
Searching for mock
Reading https://pypi.python.org/simple/mock/
Best match: mock 1.1.3
Downloading https://pypi.python.org/packages/source/m/mock/mock-1.1.3.tar.gz#md5=6da0cb632ed5ba0201c922a3de8f86ab
Processing mock-1.1.3.tar.gz
Writing /tmp/easy_install-aQbHJ1/mock-1.1.3/setup.cfg
Running mock-1.1.3/setup.py -q bdist_egg --dist-dir /tmp/easy_install-aQbHJ1/mock-1.1.3/egg-dist-tmp-Zjp_Xl
mock requires setuptools>=17.1. Aborting installation
error: Setup script exited with 1
make: *** [.venv] Error 1
```
